### PR TITLE
ci: fix auto-publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   release:
     runs-on: macos-latest
+    if: "!contains(github.event.head_commit.message, '[skip-release]')"
     permissions:
       contents: write
     steps:
@@ -14,7 +15,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check if already tagged
+        id: check
+        run: |
+          if git describe --exact-match HEAD 2>/dev/null; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Get next version
+        if: steps.check.outputs.skip != 'true'
         id: version
         run: |
           LATEST=$(git tag -l 'v*' | sort -V | tail -1 | sed 's/v//')
@@ -29,7 +40,12 @@ jobs:
           echo "version=$NEXT" >> $GITHUB_OUTPUT
           echo "tag=v$NEXT" >> $GITHUB_OUTPUT
 
+      - name: Build binary
+        if: steps.check.outputs.skip != 'true'
+        run: make
+
       - name: Create tag and release
+        if: steps.check.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -39,12 +55,35 @@ jobs:
             --title "${{ steps.version.outputs.tag }}" \
             --generate-notes
 
+      - name: Upload binary to release
+        if: steps.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ steps.version.outputs.tag }} reminderkit
+
       - name: Update Homebrew formula
+        if: steps.check.outputs.skip != 'true'
         env:
           TAP_TOKEN: ${{ secrets.TAP_TOKEN }}
         run: |
+          if [ -z "$TAP_TOKEN" ]; then
+            echo "::error::TAP_TOKEN secret is not set. Cannot update Homebrew formula."
+            exit 1
+          fi
+
           TAG=${{ steps.version.outputs.tag }}
-          SHA=$(curl -sL "https://github.com/johnmatthewtennant/reminderkit-cli/archive/refs/tags/${TAG}.tar.gz" | shasum -a 256 | cut -d' ' -f1)
+
+          # Wait for tarball to be available
+          for i in 1 2 3 4 5; do
+            HTTP_CODE=$(curl -sL -o /tmp/release.tar.gz -w '%{http_code}' \
+              "https://github.com/johnmatthewtennant/reminderkit-cli/archive/refs/tags/${TAG}.tar.gz")
+            if [ "$HTTP_CODE" = "200" ]; then break; fi
+            echo "Tarball not ready (HTTP $HTTP_CODE), retrying in 5s..."
+            sleep 5
+          done
+
+          SHA=$(shasum -a 256 /tmp/release.tar.gz | cut -d' ' -f1)
 
           git clone https://x-access-token:${TAP_TOKEN}@github.com/johnmatthewtennant/homebrew-tap.git /tmp/homebrew-tap
           cd /tmp/homebrew-tap


### PR DESCRIPTION
## Summary

- Adds duplicate-tag protection to prevent re-releases when the workflow re-runs on an already-tagged commit
- Fixes SHA256 computation race condition by retrying tarball download (up to 5 attempts with 5s backoff) instead of piping curl directly to shasum
- Adds `[skip-release]` commit message support to skip the release process
- Adds `TAP_TOKEN` validation with a clear `::error::` annotation
- Builds the binary and attaches it to the GitHub release for direct download

## Manual step required

The workflow still requires a `TAP_TOKEN` secret to push Homebrew formula updates. To set this up:

1. Go to https://github.com/settings/tokens
2. Create a **Fine-grained personal access token** with:
   - Repository access: `johnmatthewtennant/homebrew-tap` only
   - Permissions: Contents (read & write)
3. Go to https://github.com/johnmatthewtennant/reminderkit-cli/settings/secrets/actions
4. Add a repository secret named `TAP_TOKEN` with the PAT value

## Test plan

- [ ] Verify workflow YAML is valid (GitHub will parse it on push)
- [ ] Create PAT and set `TAP_TOKEN` secret
- [ ] Push a commit to master and verify the full pipeline succeeds
- [ ] Push a commit with `[skip-release]` and verify no release is created
- [ ] Verify pre-built binary is attached to the release
- [ ] Verify Homebrew formula is updated in the tap repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)