### PR TITLE
Add --parent-id support to the add command

### DIFF
--- a/reminderkit.m
+++ b/reminderkit.m
@@ -469,7 +469,8 @@ static int cmdAdd(id store, NSString *title, NSString *listName, NSDictionary *o
     // (when --parent-id is used without --list, listName is nil but list was derived from parent)
     NSString *resolvedListName = listName;
     if (!resolvedListName) {
-        resolvedListName = ((id (*)(id, SEL))objc_msgSend)(list, sel_registerName("name"));
+        id listStorage = ((id (*)(id, SEL))objc_msgSend)(list, sel_registerName("storage"));
+        resolvedListName = ((id (*)(id, SEL))objc_msgSend)(listStorage, sel_registerName("name"));
     }
     id created = findReminder(store, title, resolvedListName);
     if (created) printJSON(reminderToDict(created));


### PR DESCRIPTION
## Summary

- Add `--parent-id` flag to the `add` command, allowing subtask creation in one step (`reminderkit add --title "Subtask" --parent-id <id>`)
- When `--parent-id` is provided without `--list`, the list is automatically derived from the parent reminder
- When both `--parent-id` and `--list` are provided, they are validated for consistency (error if they conflict)
- Add `--parent-id` support to batch `add` operations with the same semantics
- Extract shared helper functions (`findListByObjectID`, `reparentChangeItem`) to reduce code duplication between `cmdAdd`, `cmdUpdate`, and batch add

## Test plan

- [x] All 24 existing tests pass
- [x] Happy path: create parent, add child with `--parent-id` (no `--list`), verify subtask relationship
- [x] Invalid parent ID returns "Parent not found" error
- [x] Conflicting `--list` and `--parent-id` returns conflict error
- [x] Matching `--list` and `--parent-id` succeeds
- [x] Batch add with `--parent-id` and explicit list works
- [x] Batch add with `--parent-id` and no list (auto-derives from parent in non-default list) works

🤖 Generated with [Claude Code](https://claude.com/claude-code)