### PR TITLE
Fix make generate: add missing normalizeQuotes definition

### DIFF
--- a/generate-cli.py
+++ b/generate-cli.py
@@ -160,6 +160,13 @@ static NSDateComponents *stringToDateComps(NSString *str) {
     return comps;
 }
 
+static NSString *normalizeQuotes(NSString *str) {
+    if (!str) return nil;
+    NSString *result = [str stringByReplacingOccurrencesOfString:@"\\u2018" withString:@"'"];
+    result = [result stringByReplacingOccurrencesOfString:@"\\u2019" withString:@"'"];
+    return result;
+}
+
 static void printJSON(id obj) {
     NSError *error = nil;
     NSData *data = [NSJSONSerialization dataWithJSONObject:obj


### PR DESCRIPTION
## Summary
- Added the `normalizeQuotes` function definition to `generate-cli.py` so that `make generate` produces compilable code
- The function was referenced in generated `findReminders` code but its definition was never included in the generator
- The existing `reminderkit.m` (manually maintained) already had this function, so only the generator was broken

## Test plan
- [x] `python3 generate-cli.py > /tmp/test.m && clang -framework Foundation -lobjc -O2 /tmp/test.m -o /dev/null` compiles successfully
- [x] `make generate` completes without errors
- [x] Built binary passes smoke test (`reminderkit lists`, `reminderkit search`)

## Manual verification
- Ran `make generate` in worktree -- succeeded (previously would fail with `normalizeQuotes` undefined)
- Built the generated binary and ran `reminderkit search --title "make generate" --list "Reminders CLI"` -- returned correct results
- Verified the generated `normalizeQuotes` function correctly replaces Unicode curly quotes (U+2018, U+2019) with straight apostrophes

🤖 Generated with [Claude Code](https://claude.com/claude-code)