### PR TITLE
Add --parent flag and fix --to-list cross-list move

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ reminderkit lists
 reminderkit list (<name> | --name <name>)
 reminderkit get (<title> | --title <title>) [--list <name>]
 reminderkit add (<title> | --title <title>) [--list <name>] [--notes <value>]
-reminderkit update (<title> | --title <title> | --id <id>) [--list <name>] [--notes <value>] [--parent-title <title>] [--to-list <name>]
+reminderkit update (<title> | --title <title> | --id <id>) [--list <name>] [--notes <value>] [--parent <title>] [--parent-id <id>] [--to-list <name>]
 reminderkit complete (<title> | --title <title> | --id <id>) [--list <name>]
 reminderkit delete (<title> | --title <title> | --id <id>) [--list <name>]
 reminderkit subtasks (<title> | --title <title>) [--list <name>]

--- a/generate-cli.py
+++ b/generate-cli.py
@@ -791,8 +791,7 @@ def generate_update_command():
         '    NSString *parentID = opts[@"parent-id"];',
         '    if (opts[@"parent"]) {',
         '        if (parentID) errorExit(@"Cannot specify both --parent and --parent-id");',
-        '        id parentByTitle = findReminder(store, opts[@"parent"], listName);',
-        '        if (!parentByTitle) errorExit([NSString stringWithFormat:@"Parent not found with title: %@", opts[@"parent"]]);',
+        '        id parentByTitle = requireUniqueReminder(store, opts[@"parent"], listName);',
         '        parentID = objectIDToString(((id (*)(id, SEL))objc_msgSend)(parentByTitle, sel_registerName("objectID")));',
         '    }',
         '',
@@ -800,6 +799,9 @@ def generate_update_command():
         '    BOOL removeParent = opts[@"remove-parent"] != nil;',
         '    if (parentID && removeParent) {',
         '        errorExit(@"Cannot specify both --parent-id/--parent and --remove-parent");',
+        '    }',
+        '    if (parentID && opts[@"to-list"]) {',
+        '        errorExit(@"Cannot combine --parent-id/--parent with --to-list (parent must be in the same list)");',
         '    }',
         '',
         '    id saveReq = ((id (*)(id, SEL, id))objc_msgSend)(',
@@ -997,7 +999,7 @@ static int cmdBatch(id store) {
     NSSet *validKeys = [NSSet setWithArray:@[@"op", @"title", @"id", @"list",
         @"notes", @"priority", @"flagged", @"completed",
         @"due-date", @"start-date", @"url", @"remove-parent", @"remove-from-list",
-        @"parent-id", @"parent", @"to-list"]];
+        @"parent-id", @"to-list"]];
 
     // Validate all operations first
     for (NSUInteger i = 0; i < ops.count; i++) {

--- a/reminderkit.m
+++ b/reminderkit.m
@@ -744,8 +744,7 @@ static int cmdUpdate(id store, NSString *listName, NSDictionary *opts) {
     NSString *parentID = opts[@"parent-id"];
     if (opts[@"parent"]) {
         if (parentID) errorExit(@"Cannot specify both --parent and --parent-id");
-        id parentByTitle = findReminder(store, opts[@"parent"], listName);
-        if (!parentByTitle) errorExit([NSString stringWithFormat:@"Parent not found with title: %@", opts[@"parent"]]);
+        id parentByTitle = requireUniqueReminder(store, opts[@"parent"], listName);
         parentID = objectIDToString(((id (*)(id, SEL))objc_msgSend)(parentByTitle, sel_registerName("objectID")));
     }
 
@@ -753,6 +752,9 @@ static int cmdUpdate(id store, NSString *listName, NSDictionary *opts) {
     BOOL removeParent = opts[@"remove-parent"] != nil;
     if (parentID && removeParent) {
         errorExit(@"Cannot specify both --parent-id/--parent and --remove-parent");
+    }
+    if (parentID && opts[@"to-list"]) {
+        errorExit(@"Cannot combine --parent-id/--parent with --to-list (parent must be in the same list)");
     }
 
     id saveReq = ((id (*)(id, SEL, id))objc_msgSend)(
@@ -946,7 +948,7 @@ static int cmdBatch(id store) {
     NSSet *validKeys = [NSSet setWithArray:@[@"op", @"title", @"id", @"list",
         @"notes", @"priority", @"flagged", @"completed",
         @"due-date", @"start-date", @"url", @"remove-parent", @"remove-from-list",
-        @"parent-id", @"parent", @"to-list"]];
+        @"parent-id", @"to-list"]];
 
     // Validate all operations first
     for (NSUInteger i = 0; i < ops.count; i++) {
@@ -1453,8 +1455,10 @@ static int cmdTest(id store) {
                 if (r != 0) { fprintf(stderr, "  FAIL (update returned %d)\n", r); failed++; }
                 else {
                     id movedRem = findReminder(store, moveTitle, destListName);
-                    if (movedRem) { fprintf(stderr, "  PASS\n"); passed++; }
-                    else { fprintf(stderr, "  FAIL (reminder not found in dest list)\n"); failed++; }
+                    id staleRem = findReminder(store, moveTitle, testListName);
+                    if (movedRem && !staleRem) { fprintf(stderr, "  PASS\n"); passed++; }
+                    else if (!movedRem) { fprintf(stderr, "  FAIL (reminder not found in dest list)\n"); failed++; }
+                    else { fprintf(stderr, "  FAIL (reminder still in source list after move)\n"); failed++; }
                 }
                 // Clean up moved reminder
                 id cleanRem = findReminder(store, moveTitle, destListName);


### PR DESCRIPTION
## Summary
- Add `--parent <title>` flag to `update` command as a title-based alternative to `--parent-id` for reparenting reminders
- Fix `--to-list` cross-list move implementation: replaced non-functional `initWithReminderChangeItem:insertIntoListChangeItem:` with `removeFromList` + `addReminderChangeItem:` approach
- Add validation: reject `--parent`/`--parent-id` combined with `--to-list` (parent must be in same list)
- Use `requireUniqueReminder` for `--parent` to error on duplicate title matches
- Add test 29 (cross-list move with source-absence verification) and test 30 (title-based reparenting)
- Update `generate-cli.py` and `README.md` to stay in sync

## Test plan
- [x] `make reminderkit` compiles without warnings
- [x] `./reminderkit test` passes: 31 passed, 2 failed (pre-existing normalized fallback failures)
- [x] Test 29: creates reminder in source list, moves via `--to-list`, verifies found in dest + absent from source
- [x] Test 30: creates reminder, reparents via `--parent <title>`, verifies parentReminderID matches
- [x] Codex review: approved after 2 rounds (unique resolution, source checks, validations added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)