### PR TITLE
Add issue-reporting instructions to CLI help

### DIFF
--- a/generate-cli.py
+++ b/generate-cli.py
@@ -1993,6 +1993,8 @@ static void usage(void) {
     fprintf(stderr, "  reminderkit install-skill [--claude] [--agents] [--force]\\n");
     fprintf(stderr, "\\n  Testing:\\n");
     fprintf(stderr, "  reminderkit test\\n");
+    fprintf(stderr, "\\n  Report issues:\\n");
+    fprintf(stderr, "  gh api repos/johnmatthewtennant/reminderkit-cli/issues --method POST -f title=\\"...\\" -f body=\\"...\\"\\n");
 }
 '''
 

--- a/reminderkit.m
+++ b/reminderkit.m
@@ -36,6 +36,8 @@ static void usage(void) {
     fprintf(stderr, "  reminderkit install-skill [--claude] [--agents] [--force]\n");
     fprintf(stderr, "\n  Testing:\n");
     fprintf(stderr, "  reminderkit test\n");
+    fprintf(stderr, "\n  Report issues:\n");
+    fprintf(stderr, "  gh api repos/johnmatthewtennant/reminderkit-cli/issues --method POST -f title=\"...\" -f body=\"...\"\n");
 }
 
 


### PR DESCRIPTION
## Summary
- Adds a "Report issues" section to the CLI help/usage output
- Shows users how to file GitHub issues using `gh api repos/johnmatthewtennant/reminderkit-cli/issues --method POST`
- Updated both `reminderkit.m` and `generate-cli.py` to keep them in sync

## Verification
- [x] Build succeeds (`make`)
- [x] All tests pass (`./reminderkit test`)
- [x] Help output displays the new section correctly

## Test plan
- Run `reminderkit` with no arguments and verify the "Report issues" section appears at the bottom of the help output

🤖 Generated with [Claude Code](https://claude.com/claude-code)