### PR TITLE
Add --title flag to update command usage

### DIFF
--- a/.agents/skills/apple-reminders/SKILL.md
+++ b/.agents/skills/apple-reminders/SKILL.md
@@ -33,6 +33,7 @@ Command-line interface for Apple Reminders. Built on the private ReminderKit fra
 - `reminderkit get --title "Title" --list "List"` — find a reminder by title
 - `reminderkit get --url <url> [--list "List"]` — find a reminder by URL field (normalizes trailing slashes)
 - `reminderkit get --id <id>` — fetch a reminder by ID (faster, no list scan needed)
+- `reminderkit update --id <id> --title "New Title"` — rename a reminder
 
 ## Linking reminders to Apple Notes
 

--- a/generate-cli.py
+++ b/generate-cli.py
@@ -2145,7 +2145,7 @@ static void usage(void) {
     fprintf(stderr, "  reminderkit get --id <id>\\n");
     fprintf(stderr, "  reminderkit subtasks --title <title> [--list <name>]\\n");
     fprintf(stderr, "  reminderkit add --title <title> [--list <name>] [--notes <value>] [--completed <value>] [--priority <value>] [--flagged <value>] [--due-date <value>] [--start-date <value>] [--url <value>] [--parent-id <id>]\\n");
-    fprintf(stderr, "  reminderkit update --id <id> [--list <name>] [--notes <value>] [--append-notes <value>] [--completed <value>] [--priority <value>] [--flagged <value>] [--due-date <value>] [--start-date <value>] [--url <value>] [--clear-url] [--remove-parent] [--remove-from-list] [--parent-id <id>] [--to-list <name>]\\n");
+    fprintf(stderr, "  reminderkit update --id <id> [--title <value>] [--list <name>] [--notes <value>] [--append-notes <value>] [--completed <value>] [--priority <value>] [--flagged <value>] [--due-date <value>] [--start-date <value>] [--url <value>] [--clear-url] [--remove-parent] [--remove-from-list] [--parent-id <id>] [--to-list <name>]\\n");
     fprintf(stderr, "  reminderkit complete --id <id> [--list <name>]\\n");
     fprintf(stderr, "  reminderkit delete --id <id> [--list <name>]\\n");
     fprintf(stderr, "  reminderkit add-tag --id <id> --tag <tag-name>\\n");

--- a/reminderkit.m
+++ b/reminderkit.m
@@ -23,7 +23,7 @@ static void usage(void) {
     fprintf(stderr, "  reminderkit get --id <id>\n");
     fprintf(stderr, "  reminderkit subtasks --title <title> [--list <name>]\n");
     fprintf(stderr, "  reminderkit add --title <title> [--list <name>] [--notes <value>] [--completed <value>] [--priority <value>] [--flagged <value>] [--due-date <value>] [--start-date <value>] [--url <value>] [--parent-id <id>]\n");
-    fprintf(stderr, "  reminderkit update --id <id> [--list <name>] [--notes <value>] [--append-notes <value>] [--completed <value>] [--priority <value>] [--flagged <value>] [--due-date <value>] [--start-date <value>] [--url <value>] [--clear-url] [--remove-parent] [--remove-from-list] [--parent-id <id>] [--to-list <name>]\n");
+    fprintf(stderr, "  reminderkit update --id <id> [--title <value>] [--list <name>] [--notes <value>] [--append-notes <value>] [--completed <value>] [--priority <value>] [--flagged <value>] [--due-date <value>] [--start-date <value>] [--url <value>] [--clear-url] [--remove-parent] [--remove-from-list] [--parent-id <id>] [--to-list <name>]\n");
     fprintf(stderr, "  reminderkit complete --id <id> [--list <name>]\n");
     fprintf(stderr, "  reminderkit delete --id <id> [--list <name>]\n");
     fprintf(stderr, "  reminderkit add-tag --id <id> --tag <tag-name>\n");


### PR DESCRIPTION
## Summary
- Documents the existing `--title` flag in the `update` command's usage string
- The backend (`cmdUpdate`) already supported renaming via `--title`, but it wasn't shown in `--help`
- Adds a rename example to the apple-reminders skill docs

## Test plan
- [x] All 47 tests pass (0 failures), including Test 15 which specifically tests rename via update
- [x] Verified `reminderkit update --help` shows `[--title <value>]`
- [x] Installed updated binary and skill docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)