### PR TITLE
Fix --flagged true/false being silently ignored

### DIFF
--- a/generate-cli.py
+++ b/generate-cli.py
@@ -77,7 +77,7 @@ REMINDER_WRITE_OPS = {
     "notes":        ("setNotesAsString:",       "string"),
     "completed":    ("setCompleted:",           "bool"),
     "priority":     ("setPriority:",            "uint"),
-    "flagged":      ("setFlagged:",             "int"),
+    "flagged":      ("setFlagged:",             "bool"),
     "due-date":     ("setDueDateComponents:",   "datecomps"),
     "start-date":   ("setStartDateComponents:", "datecomps"),
     "url":          (None,                      "url"),  # handled specially
@@ -125,6 +125,11 @@ static id getStore(void) {
 static void errorExit(NSString *msg) {
     fprintf(stderr, "Error: %s\\n", [msg UTF8String]);
     exit(1);
+}
+
+static BOOL parseBoolString(NSString *str) {
+    NSString *lower = [str lowercaseString];
+    return [lower isEqualToString:@"true"] || [lower isEqualToString:@"1"] || [lower isEqualToString:@"yes"];
 }
 
 static NSString *objectIDToString(id objID) {
@@ -1143,7 +1148,7 @@ def generate_update_command():
             lines.append(f'    }}')
         elif arg_type == "bool":
             lines.append(f'    if (opts[@"{flag}"]) {{')
-            lines.append(f'        BOOL val = [opts[@"{flag}"] isEqualToString:@"true"];')
+            lines.append(f'        BOOL val = parseBoolString(opts[@"{flag}"]);')
             lines.append(f'        ((void (*)(id, SEL, BOOL))objc_msgSend)(changeItem, sel_registerName("{setter}"), val);')
             lines.append(f'    }}')
         elif arg_type == "uint":
@@ -1267,7 +1272,7 @@ def generate_add_setters():
             lines.append(f'    }}')
         elif arg_type == "bool":
             lines.append(f'    if (opts[@"{flag}"]) {{')
-            lines.append(f'        BOOL val = [opts[@"{flag}"] isEqualToString:@"true"];')
+            lines.append(f'        BOOL val = parseBoolString(opts[@"{flag}"]);')
             lines.append(f'        ((void (*)(id, SEL, BOOL))objc_msgSend)(newRem, sel_registerName("{setter}"), val);')
             lines.append(f'    }}')
         elif arg_type == "uint":

--- a/reminderkit-generated.m
+++ b/reminderkit-generated.m
@@ -34,6 +34,11 @@ static void errorExit(NSString *msg) {
     exit(1);
 }
 
+static BOOL parseBoolString(NSString *str) {
+    NSString *lower = [str lowercaseString];
+    return [lower isEqualToString:@"true"] || [lower isEqualToString:@"1"] || [lower isEqualToString:@"yes"];
+}
+
 static NSString *objectIDToString(id objID) {
     if (!objID) return nil;
     return [objID description];
@@ -792,7 +797,7 @@ static int cmdAdd(id store, NSString *title, NSString *listName, NSDictionary *o
         ((void (*)(id, SEL, id))objc_msgSend)(newRem, sel_registerName("setNotesAsString:"), opts[@"notes"]);
     }
     if (opts[@"completed"]) {
-        BOOL val = [opts[@"completed"] isEqualToString:@"true"];
+        BOOL val = parseBoolString(opts[@"completed"]);
         ((void (*)(id, SEL, BOOL))objc_msgSend)(newRem, sel_registerName("setCompleted:"), val);
     }
     if (opts[@"priority"]) {
@@ -800,8 +805,8 @@ static int cmdAdd(id store, NSString *title, NSString *listName, NSDictionary *o
         ((void (*)(id, SEL, NSUInteger))objc_msgSend)(newRem, sel_registerName("setPriority:"), val);
     }
     if (opts[@"flagged"]) {
-        NSInteger val = [opts[@"flagged"] integerValue];
-        ((void (*)(id, SEL, NSInteger))objc_msgSend)(newRem, sel_registerName("setFlagged:"), val);
+        BOOL val = parseBoolString(opts[@"flagged"]);
+        ((void (*)(id, SEL, BOOL))objc_msgSend)(newRem, sel_registerName("setFlagged:"), val);
     }
     if (opts[@"due-date"]) {
         NSDateComponents *comps = stringToDateComps(opts[@"due-date"]);
@@ -1082,7 +1087,7 @@ static int cmdUpdate(id store, NSString *listName, NSDictionary *opts) {
         ((void (*)(id, SEL, id))objc_msgSend)(changeItem, sel_registerName("setNotesAsString:"), opts[@"notes"]);
     }
     if (opts[@"completed"]) {
-        BOOL val = [opts[@"completed"] isEqualToString:@"true"];
+        BOOL val = parseBoolString(opts[@"completed"]);
         ((void (*)(id, SEL, BOOL))objc_msgSend)(changeItem, sel_registerName("setCompleted:"), val);
     }
     if (opts[@"priority"]) {
@@ -1090,8 +1095,8 @@ static int cmdUpdate(id store, NSString *listName, NSDictionary *opts) {
         ((void (*)(id, SEL, NSUInteger))objc_msgSend)(changeItem, sel_registerName("setPriority:"), val);
     }
     if (opts[@"flagged"]) {
-        NSInteger val = [opts[@"flagged"] integerValue];
-        ((void (*)(id, SEL, NSInteger))objc_msgSend)(changeItem, sel_registerName("setFlagged:"), val);
+        BOOL val = parseBoolString(opts[@"flagged"]);
+        ((void (*)(id, SEL, BOOL))objc_msgSend)(changeItem, sel_registerName("setFlagged:"), val);
     }
     if (opts[@"due-date"]) {
         NSDateComponents *comps = stringToDateComps(opts[@"due-date"]);

--- a/reminderkit-handwritten.m
+++ b/reminderkit-handwritten.m
@@ -129,12 +129,12 @@ static int cmdBatch(id store) {
             // Apply optional properties on the new reminder change item
             if (op[@"notes"]) ((void (*)(id, SEL, id))objc_msgSend)(newRem, sel_registerName("setNotesAsString:"), op[@"notes"]);
             if (op[@"priority"]) ((void (*)(id, SEL, NSUInteger))objc_msgSend)(newRem, sel_registerName("setPriority:"), [op[@"priority"] integerValue]);
-            if (op[@"flagged"]) ((void (*)(id, SEL, NSInteger))objc_msgSend)(newRem, sel_registerName("setFlagged:"), [op[@"flagged"] integerValue]);
+            if (op[@"flagged"]) ((void (*)(id, SEL, BOOL))objc_msgSend)(newRem, sel_registerName("setFlagged:"), parseBoolString(op[@"flagged"]));
             if (op[@"due-date"]) ((void (*)(id, SEL, id))objc_msgSend)(newRem, sel_registerName("setDueDateComponents:"), stringToDateComps(op[@"due-date"]));
             if (op[@"start-date"]) ((void (*)(id, SEL, id))objc_msgSend)(newRem, sel_registerName("setStartDateComponents:"), stringToDateComps(op[@"start-date"]));
             if (op[@"url"]) { NSURL *u = [NSURL URLWithString:op[@"url"]]; if (u) { id attCtx = ((id (*)(id, SEL))objc_msgSend)(newRem, sel_registerName("attachmentContext")); ((void (*)(id, SEL, id))objc_msgSend)(attCtx, sel_registerName("setURLAttachmentWithURL:"), u); } }
             if (op[@"completed"]) {
-                BOOL val = [op[@"completed"] isEqualToString:@"true"];
+                BOOL val = parseBoolString(op[@"completed"]);
                 ((void (*)(id, SEL, BOOL))objc_msgSend)(newRem, sel_registerName("setCompleted:"), val);
             }
 
@@ -179,9 +179,9 @@ static int cmdBatch(id store) {
                     ((void (*)(id, SEL, id))objc_msgSend)(changeItem, sel_registerName("setNotesAsString:"), op[@"notes"]);
                 }
                 if (op[@"priority"]) ((void (*)(id, SEL, NSUInteger))objc_msgSend)(changeItem, sel_registerName("setPriority:"), [op[@"priority"] integerValue]);
-                if (op[@"flagged"]) ((void (*)(id, SEL, NSInteger))objc_msgSend)(changeItem, sel_registerName("setFlagged:"), [op[@"flagged"] integerValue]);
+                if (op[@"flagged"]) ((void (*)(id, SEL, BOOL))objc_msgSend)(changeItem, sel_registerName("setFlagged:"), parseBoolString(op[@"flagged"]));
                 if (op[@"completed"]) {
-                    BOOL val = [op[@"completed"] isEqualToString:@"true"];
+                    BOOL val = parseBoolString(op[@"completed"]);
                     ((void (*)(id, SEL, BOOL))objc_msgSend)(changeItem, sel_registerName("setCompleted:"), val);
                 }
                 if (op[@"due-date"]) ((void (*)(id, SEL, id))objc_msgSend)(changeItem, sel_registerName("setDueDateComponents:"), stringToDateComps(op[@"due-date"]));


### PR DESCRIPTION
## Summary

- `--flagged true` was silently ignored because the flag used `integerValue` to parse, which returns `0` for non-numeric strings like `"true"`
- Changed flagged from `int` to `bool` type in the code generator, matching how `--completed` already works
- Added `parseBoolString()` helper that accepts `"true"`, `"yes"`, `"1"` (case-insensitive) for both `--flagged` and `--completed`
- Backward compatible: `--flagged 1` and `--flagged 0` still work

## Test plan

- [x] `--flagged true` sets flag (`flagged: 1` in output)
- [x] `--flagged false` clears flag (`flagged: 0`)
- [x] `--flagged 1` still works (backward compat)
- [x] All 59 built-in tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)