### PR TITLE
Fix version drift: derive embedded version from build (#38)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Build binary
         if: steps.check.outputs.skip != 'true'
-        run: make
+        run: make VERSION=${{ steps.version.outputs.version }}
 
       - name: Create tag and release
         if: steps.check.outputs.skip != 'true'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 CC = clang
-CFLAGS = -framework Foundation -framework EventKit -lobjc -O2
+# Version embedded in the binary. The Homebrew formula passes VERSION=#{version}
+# (the release tag); local builds fall back to the latest git tag, then "dev".
+VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo dev)
+CFLAGS = -framework Foundation -framework EventKit -lobjc -O2 -DREMINDERKIT_VERSION='"$(VERSION)"'
 INFO_PLIST = Info.plist
 BUNDLE_ID = com.jtennant.reminderkit-cli
 INFO_PLIST_FLAGS = -Wl,-sectcreate,__TEXT,__info_plist,$(INFO_PLIST)

--- a/reminderkit-version-check.m
+++ b/reminderkit-version-check.m
@@ -1,94 +1,16 @@
-// Version checks and background Homebrew upgrades.
+// Version string and background Homebrew upgrades.
 
-static NSString * const ReminderkitCurrentVersion = @"0.5.52";
-static NSString * const ReminderkitFormulaURL = @"https://raw.githubusercontent.com/johnmatthewtennant/homebrew-tap/master/Formula/reminderkit-cli.rb";
+// The version is injected at build time via -DREMINDERKIT_VERSION (passed by
+// the Homebrew formula as VERSION=#{version} and by the release workflow). The
+// "dev" fallback applies only to ad-hoc local builds, keeping the embedded
+// version in lockstep with the release tag instead of a hand-edited constant.
+#ifndef REMINDERKIT_VERSION
+#define REMINDERKIT_VERSION "dev"
+#endif
+static NSString * const ReminderkitCurrentVersion = @REMINDERKIT_VERSION;
 static NSString * const ReminderkitFormulaTap = @"johnmatthewtennant/tap/reminderkit-cli";
 static NSString * const ReminderkitFormulaName = @"reminderkit-cli";
 static NSString * const ReminderkitCommandName = @"reminderkit";
-
-static NSString *parseFormulaVersion(NSString *formulaBody) {
-    __block NSString *version = nil;
-    [formulaBody enumerateLinesUsingBlock:^(NSString *line, BOOL *stop) {
-        NSString *trimmed = [line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-        if ([trimmed hasPrefix:@"version \""]) {
-            NSString *rest = [trimmed substringFromIndex:[@"version \"" length]];
-            NSRange closing = [rest rangeOfString:@"\""];
-            if (closing.location != NSNotFound) {
-                version = [rest substringToIndex:closing.location];
-                *stop = YES;
-            }
-        }
-
-        NSRange tagRange = [trimmed rangeOfString:@"archive/refs/tags/v"];
-        if (tagRange.location != NSNotFound) {
-            NSUInteger start = tagRange.location + tagRange.length;
-            NSString *rest = [trimmed substringFromIndex:start];
-            NSRange end = [rest rangeOfString:@".tar.gz"];
-            if (end.location != NSNotFound) {
-                version = [rest substringToIndex:end.location];
-                *stop = YES;
-            }
-        }
-    }];
-    return version;
-}
-
-static NSString *latestKnownVersion(NSTimeInterval timeout) {
-    NSURL *url = [NSURL URLWithString:ReminderkitFormulaURL];
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
-    [request setTimeoutInterval:timeout];
-
-    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
-    __block NSData *data = nil;
-    __block NSURLResponse *response = nil;
-    __block NSError *error = nil;
-    NSURLSessionDataTask *task = [[NSURLSession sharedSession]
-        dataTaskWithRequest:request
-        completionHandler:^(NSData *taskData, NSURLResponse *taskResponse, NSError *taskError) {
-            data = taskData;
-            response = taskResponse;
-            error = taskError;
-            dispatch_semaphore_signal(sema);
-        }];
-    [task resume];
-
-    dispatch_time_t deadline = dispatch_time(DISPATCH_TIME_NOW, (int64_t)((timeout + 1) * NSEC_PER_SEC));
-    if (dispatch_semaphore_wait(sema, deadline) != 0) {
-        [task cancel];
-        return nil;
-    }
-
-    if (error || !data) return nil;
-    if ([response isKindOfClass:[NSHTTPURLResponse class]] &&
-        [(NSHTTPURLResponse *)response statusCode] != 200) {
-        return nil;
-    }
-
-    NSString *body = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-    if (!body) return nil;
-    return parseFormulaVersion(body);
-}
-
-static BOOL isOutdated(NSString *current, NSString *latest) {
-    NSArray *currentParts = [current componentsSeparatedByString:@"."];
-    NSArray *latestParts = [latest componentsSeparatedByString:@"."];
-    NSUInteger maxCount = MAX([currentParts count], [latestParts count]);
-
-    for (NSUInteger i = 0; i < maxCount; i++) {
-        NSInteger c = i < [currentParts count] ? [currentParts[i] integerValue] : 0;
-        NSInteger l = i < [latestParts count] ? [latestParts[i] integerValue] : 0;
-        if (l > c) return YES;
-        if (l < c) return NO;
-    }
-    return NO;
-}
-
-static NSString *outdatedWarning(NSString *latest) {
-    if (!latest || !isOutdated(ReminderkitCurrentVersion, latest)) return nil;
-    return [NSString stringWithFormat:
-        @"reminderkit %@ is outdated. Latest: %@. Run: brew upgrade %@",
-        ReminderkitCurrentVersion, latest, ReminderkitFormulaTap];
-}
 
 static BOOL shouldAttemptUpgrade(NSDate *now, NSDate *lastAttempt) {
     if (!lastAttempt) return YES;
@@ -137,11 +59,9 @@ static void attemptBackgroundUpgrade(void) {
 }
 
 static int cmdVersion(BOOL skipCheck) {
+    // Background auto-upgrade (attemptBackgroundUpgrade) keeps brew installs
+    // current, so there is no separate outdated-version network check.
+    (void)skipCheck;
     printf("reminderkit %s\n", [ReminderkitCurrentVersion UTF8String]);
-    if (!skipCheck) {
-        NSString *latest = latestKnownVersion(2);
-        NSString *warning = outdatedWarning(latest);
-        if (warning) fprintf(stderr, "%s\n", [warning UTF8String]);
-    }
     return 0;
 }


### PR DESCRIPTION
Fixes #38.

## Problem
The embedded `ReminderkitCurrentVersion` was a hand-maintained constant (`@"0.5.52"`) that drifted from the release tag. A 0.5.52 binary warned it was outdated against tag 0.5.56 because the warning compared the stale constant against the live formula version, even though the actual install was current.

## Fix
- **Inject the version at build time** via `-DREMINDERKIT_VERSION`. The Homebrew formula passes `VERSION=#{version}` (the release tag) and the release workflow passes the computed version, so the embedded string is always exactly the tag. Local builds fall back to the latest git tag, then `dev`. Single source of truth, no hand-editing.
- **Remove the outdated-version network check** (`parseFormulaVersion`/`latestKnownVersion`/`isOutdated`/`outdatedWarning`). Background auto-upgrade (`attemptBackgroundUpgrade`) already keeps brew installs current within 24h, and the warning only ever appeared on `reminderkit version`. Dropping it removes the formula-fetch path and the only remaining drift-driven false warning.

## Companion change
The required Homebrew formula change has landed in `johnmatthewtennant/homebrew-tap` (`b736ff8`): `system "make", "VERSION=#{version}"`.

## Testing
- `make VERSION=0.5.56 && ./reminderkit version` → `reminderkit 0.5.56`
- `make && ./reminderkit version` → latest local git tag
- `./reminderkit test` → 72 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)