### PR TITLE
Fix first-run Reminders permission denial (#39)

### DIFF
--- a/generate-cli.py
+++ b/generate-cli.py
@@ -141,9 +141,13 @@ static void loadFramework(void) {
     REMMembershipsClass = NSClassFromString(@"REMMemberships");
 }
 
-static void requestRemindersAccess(void) {
+static BOOL hasRemindersAccess(void) {
     EKAuthorizationStatus status = [EKEventStore authorizationStatusForEntityType:EKEntityTypeReminder];
-    if (status == EKAuthorizationStatusAuthorized || status == EKAuthorizationStatusFullAccess) return;
+    return status == EKAuthorizationStatusAuthorized || status == EKAuthorizationStatusFullAccess;
+}
+
+static BOOL requestRemindersAccessOnce(void) {
+    if (hasRemindersAccess()) return YES;
 
     EKEventStore *eventStore = [[EKEventStore alloc] init];
     dispatch_semaphore_t sem = dispatch_semaphore_create(0);
@@ -164,10 +168,50 @@ static void requestRemindersAccess(void) {
     }
 
     dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
-    if (!granted) {
-        fprintf(stderr, "Error: Reminders access denied.\\n");
-        exit(1);
+    return granted;
+}
+
+static void printRemindersAccessDeniedHelp(void) {
+    fprintf(stderr, "Error: Reminders access denied.\\n\\n");
+    fprintf(stderr, "Your terminal app needs permission to access Reminders.\\n\\n");
+    fprintf(stderr, "1. Grant permission (triggers macOS prompt):\\n");
+    fprintf(stderr, "   osascript -e 'tell application \\"Reminders\\" to get name of every list'\\n\\n");
+    fprintf(stderr, "2. If previously denied, reset first, then re-run step 1:\\n");
+    fprintf(stderr, "   tccutil reset Reminders <bundle-id>\\n\\n");
+    fprintf(stderr, "   Find your terminal's bundle ID:\\n");
+    fprintf(stderr, "   osascript -e 'id of app \\"iTerm\\"'  (replace iTerm with your terminal app name)\\n\\n");
+    fprintf(stderr, "3. Then retry your reminderkit command.\\n");
+}
+
+static BOOL runRemindersPermissionPreflight(void) {
+    NSTask *task = [[NSTask alloc] init];
+    [task setLaunchPath:@"/usr/bin/osascript"];
+    [task setArguments:@[@"-e", @"tell application \\"Reminders\\" to get name of every list"]];
+    [task setStandardInput:[NSFileHandle fileHandleWithNullDevice]];
+    [task setStandardOutput:[NSFileHandle fileHandleWithNullDevice]];
+    [task setStandardError:[NSFileHandle fileHandleWithNullDevice]];
+
+    @try {
+        [task launch];
+        [task waitUntilExit];
+    } @catch (__unused NSException *exception) {
+        return NO;
     }
+    return [task terminationStatus] == 0;
+}
+
+static BOOL isRemindersAccessError(NSError *error) {
+    return [[error domain] isEqualToString:@"NSCocoaErrorDomain"] && [error code] == 4097;
+}
+
+static void requestRemindersAccess(void) {
+    if (requestRemindersAccessOnce()) return;
+
+    runRemindersPermissionPreflight();
+    if (requestRemindersAccessOnce()) return;
+
+    printRemindersAccessDeniedHelp();
+    exit(1);
 }
 
 static id getStore(void) {
@@ -521,17 +565,15 @@ static NSArray *fetchLists(id store) {
     NSError *error = nil;
     NSArray *lists = ((id (*)(id, SEL, id*))objc_msgSend)(
         store, sel_registerName("fetchEligibleDefaultListsWithError:"), &error);
+    if (error && isRemindersAccessError(error)) {
+        runRemindersPermissionPreflight();
+        error = nil;
+        lists = ((id (*)(id, SEL, id*))objc_msgSend)(
+            store, sel_registerName("fetchEligibleDefaultListsWithError:"), &error);
+    }
     if (error) {
-        if ([[error domain] isEqualToString:@"NSCocoaErrorDomain"] && [error code] == 4097) {
-            fprintf(stderr, "Error: Reminders access denied.\\n\\n");
-            fprintf(stderr, "Your terminal app needs permission to access Reminders.\\n\\n");
-            fprintf(stderr, "1. Grant permission (triggers macOS prompt):\\n");
-            fprintf(stderr, "   osascript -e 'tell application \\"Reminders\\" to get name of every list'\\n\\n");
-            fprintf(stderr, "2. If previously denied, reset first, then re-run step 1:\\n");
-            fprintf(stderr, "   tccutil reset Reminders <bundle-id>\\n\\n");
-            fprintf(stderr, "   Find your terminal's bundle ID:\\n");
-            fprintf(stderr, "   osascript -e 'id of app \\"iTerm\\"'  (replace iTerm with your terminal app name)\\n\\n");
-            fprintf(stderr, "3. Then retry: reminderkit lists\\n");
+        if (isRemindersAccessError(error)) {
+            printRemindersAccessDeniedHelp();
             exit(1);
         }
         errorExit([NSString stringWithFormat:@"Failed to fetch lists: %@", error]);

--- a/reminderkit-generated.m
+++ b/reminderkit-generated.m
@@ -27,9 +27,13 @@ static void loadFramework(void) {
     REMMembershipsClass = NSClassFromString(@"REMMemberships");
 }
 
-static void requestRemindersAccess(void) {
+static BOOL hasRemindersAccess(void) {
     EKAuthorizationStatus status = [EKEventStore authorizationStatusForEntityType:EKEntityTypeReminder];
-    if (status == EKAuthorizationStatusAuthorized || status == EKAuthorizationStatusFullAccess) return;
+    return status == EKAuthorizationStatusAuthorized || status == EKAuthorizationStatusFullAccess;
+}
+
+static BOOL requestRemindersAccessOnce(void) {
+    if (hasRemindersAccess()) return YES;
 
     EKEventStore *eventStore = [[EKEventStore alloc] init];
     dispatch_semaphore_t sem = dispatch_semaphore_create(0);
@@ -50,10 +54,50 @@ static void requestRemindersAccess(void) {
     }
 
     dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
-    if (!granted) {
-        fprintf(stderr, "Error: Reminders access denied.\n");
-        exit(1);
+    return granted;
+}
+
+static void printRemindersAccessDeniedHelp(void) {
+    fprintf(stderr, "Error: Reminders access denied.\n\n");
+    fprintf(stderr, "Your terminal app needs permission to access Reminders.\n\n");
+    fprintf(stderr, "1. Grant permission (triggers macOS prompt):\n");
+    fprintf(stderr, "   osascript -e 'tell application \"Reminders\" to get name of every list'\n\n");
+    fprintf(stderr, "2. If previously denied, reset first, then re-run step 1:\n");
+    fprintf(stderr, "   tccutil reset Reminders <bundle-id>\n\n");
+    fprintf(stderr, "   Find your terminal's bundle ID:\n");
+    fprintf(stderr, "   osascript -e 'id of app \"iTerm\"'  (replace iTerm with your terminal app name)\n\n");
+    fprintf(stderr, "3. Then retry your reminderkit command.\n");
+}
+
+static BOOL runRemindersPermissionPreflight(void) {
+    NSTask *task = [[NSTask alloc] init];
+    [task setLaunchPath:@"/usr/bin/osascript"];
+    [task setArguments:@[@"-e", @"tell application \"Reminders\" to get name of every list"]];
+    [task setStandardInput:[NSFileHandle fileHandleWithNullDevice]];
+    [task setStandardOutput:[NSFileHandle fileHandleWithNullDevice]];
+    [task setStandardError:[NSFileHandle fileHandleWithNullDevice]];
+
+    @try {
+        [task launch];
+        [task waitUntilExit];
+    } @catch (__unused NSException *exception) {
+        return NO;
     }
+    return [task terminationStatus] == 0;
+}
+
+static BOOL isRemindersAccessError(NSError *error) {
+    return [[error domain] isEqualToString:@"NSCocoaErrorDomain"] && [error code] == 4097;
+}
+
+static void requestRemindersAccess(void) {
+    if (requestRemindersAccessOnce()) return;
+
+    runRemindersPermissionPreflight();
+    if (requestRemindersAccessOnce()) return;
+
+    printRemindersAccessDeniedHelp();
+    exit(1);
 }
 
 static id getStore(void) {
@@ -407,17 +451,15 @@ static NSArray *fetchLists(id store) {
     NSError *error = nil;
     NSArray *lists = ((id (*)(id, SEL, id*))objc_msgSend)(
         store, sel_registerName("fetchEligibleDefaultListsWithError:"), &error);
+    if (error && isRemindersAccessError(error)) {
+        runRemindersPermissionPreflight();
+        error = nil;
+        lists = ((id (*)(id, SEL, id*))objc_msgSend)(
+            store, sel_registerName("fetchEligibleDefaultListsWithError:"), &error);
+    }
     if (error) {
-        if ([[error domain] isEqualToString:@"NSCocoaErrorDomain"] && [error code] == 4097) {
-            fprintf(stderr, "Error: Reminders access denied.\n\n");
-            fprintf(stderr, "Your terminal app needs permission to access Reminders.\n\n");
-            fprintf(stderr, "1. Grant permission (triggers macOS prompt):\n");
-            fprintf(stderr, "   osascript -e 'tell application \"Reminders\" to get name of every list'\n\n");
-            fprintf(stderr, "2. If previously denied, reset first, then re-run step 1:\n");
-            fprintf(stderr, "   tccutil reset Reminders <bundle-id>\n\n");
-            fprintf(stderr, "   Find your terminal's bundle ID:\n");
-            fprintf(stderr, "   osascript -e 'id of app \"iTerm\"'  (replace iTerm with your terminal app name)\n\n");
-            fprintf(stderr, "3. Then retry: reminderkit lists\n");
+        if (isRemindersAccessError(error)) {
+            printRemindersAccessDeniedHelp();
             exit(1);
         }
         errorExit([NSString stringWithFormat:@"Failed to fetch lists: %@", error]);

--- a/reminderkit-tests.m
+++ b/reminderkit-tests.m
@@ -156,6 +156,14 @@ static int cmdTest(id store) {
     NSString *parentTitle = @"__remcli_test_parent__";
     NSString *childTitle = @"__remcli_test_child__";
 
+    // Test 0: Reminders access error classifier
+    fprintf(stderr, "Test 0a: isRemindersAccessError recognizes 4097...\n");
+    { NSError *e = [NSError errorWithDomain:@"NSCocoaErrorDomain" code:4097 userInfo:nil]; if (isRemindersAccessError(e)) { fprintf(stderr, "  PASS\n"); passed++; } else { fprintf(stderr, "  FAIL\n"); failed++; } }
+    fprintf(stderr, "Test 0b: isRemindersAccessError ignores other Cocoa errors...\n");
+    { NSError *e = [NSError errorWithDomain:@"NSCocoaErrorDomain" code:1 userInfo:nil]; if (!isRemindersAccessError(e)) { fprintf(stderr, "  PASS\n"); passed++; } else { fprintf(stderr, "  FAIL\n"); failed++; } }
+    fprintf(stderr, "Test 0c: isRemindersAccessError ignores nil...\n");
+    { if (!isRemindersAccessError(nil)) { fprintf(stderr, "  PASS\n"); passed++; } else { fprintf(stderr, "  FAIL\n"); failed++; } }
+
     // Cleanup leftover test data
     id oldList = findList(store, testListName);
     if (oldList) {


### PR DESCRIPTION
Fixes #39.

## Problem
`reminderkit` had two different permission-denial paths:

- `requestRemindersAccess()` printed only `Error: Reminders access denied.`
- `fetchLists()` printed longer AppleScript guidance only after the later private ReminderKit 4097 failure

That made the first-run experience uneven and still required users to manually discover or run the AppleScript probe that surfaces the macOS Reminders permission prompt.

## Fix
- Add shared Reminders access-denial helpers:
  - `printRemindersAccessDeniedHelp()`
  - `runRemindersPermissionPreflight()`
  - `isRemindersAccessError()`
- On a denial from `requestRemindersAccess()`, run the tiny AppleScript preflight once, retry EventKit access once, then print fallback guidance if still denied.
- On a private ReminderKit 4097 denial from `fetchLists()`, run the same preflight once, retry the original fetch once, then print the same fallback guidance if still denied.
- Keep the preflight on denial paths only, so normal successful commands do not invoke AppleScript or open Reminders prompts.

## Testing
- `python3 generate-cli.py > reminderkit-generated.m`
- `make reminderkit` → success (existing EventKit deprecation warnings only)
- `./reminderkit test` → 75 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)