### PR TITLE
Harden release: retry tap push on concurrent-release race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,4 +97,17 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Formula/reminderkit-cli.rb
           git commit -m "reminderkit-cli: bump to ${TAG}"
-          git push
+
+          # The tap is shared across formulae, so a concurrent release can move
+          # master between our clone and push. Rebase and retry on rejection.
+          for attempt in 1 2 3 4 5; do
+            if git push; then
+              break
+            fi
+            if [ "$attempt" = "5" ]; then
+              echo "::error::Failed to push formula bump after 5 attempts."
+              exit 1
+            fi
+            echo "Push rejected, rebasing on latest tap master (attempt $attempt)..."
+            git pull --rebase origin master
+          done


### PR DESCRIPTION
## Problem
The `Auto Release & Homebrew Bump` workflow clones the shared `homebrew-tap`, commits the formula bump, and runs a bare `git push`. The tap is shared across formulae, so when another repo releases at the same time, the tap's `master` moves between clone and push and the push is rejected:

```
! [rejected]        master -> master (fetch first)
error: failed to push some refs
```

This just happened: the v0.5.57 release was tagged and the binary uploaded, but the formula bump push lost a race with a concurrent notekit release, so the formula stayed at v0.5.56. (The tap has since been corrected manually.)

## Fix
Wrap the push in a rebase-and-retry loop (5 attempts). On rejection, `git pull --rebase origin master` and retry; the formula edit only touches this repo's `url`/`sha256` lines, so the rebase is clean against another formula's bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)